### PR TITLE
Added GtkInfoBar, GtkSpinner, Gtk Markup Escaping and Condition Handling in GtkInfoBar

### DIFF
--- a/cairo/cairo.lisp
+++ b/cairo/cairo.lisp
@@ -4,9 +4,9 @@
 
 (defclass gdk-context (cl-cairo2:context)
   ())
-                          
+
 (defun create-gdk-context (gdk-drawable)
-  "creates an context to draw on a GTK widget, more precisely on the
+  "Creates a context to draw on a GTK widget, more precisely on the
 associated gdk-window.  This should only be called from within the
 expose event.  In cells-gtk, use (gtk-adds-widget-window gtk-pointer)
 to obtain the gdk-window. 'gtk-pointer' is the pointer parameter

--- a/generating.lisp
+++ b/generating.lisp
@@ -70,7 +70,7 @@
                 "GtkTextTagTable" "GtkTreeModelFilter" "GtkTreeModelSort"
                 "GtkTreeSelection" "GtkTreeStore" "GtkUIManager" "GtkWindowGroup"
                 "GtkToggleAction" "GtkRecentAction" "GtkRadioAction" "GtkItemFactory"
-		"GtkPageSetupUnixDialog" "GtkPrintUnixDialog")
+		"GtkPageSetupUnixDialog" "GtkPrintUnixDialog" "GtkInfoBar")
      :flags '("GtkTextSearchFlags" "GtkAccelFlags" "GtkArgFlags" "GtkAttachOptions"
               "GtkButtonAction" "GtkCalendarDisplayOptions" "GtkCellRendererState"
               "GtkDebugFlag" "GtkDestDefaults" "GtkDialogFlags" "GtkFileFilterFlags"
@@ -369,7 +369,12 @@
          "gtk_bin_get_child" nil))
        ("GtkTextChildAnchor"
         (:cffi gtk::deleted-p gtk::text-child-anchor-deleted-p :boolean
-         "gtk_text_child_anchor_get_deleted" nil))))))
+         "gtk_text_child_anchor_get_deleted" nil))
+       ("GtkInfoBar"
+	(:cffi gtk::action-area gtk::info-bar-action-area (g-object gtk::widget)
+	 "gtk_info_bar_get_action_area" nil)
+	(:cffi gtk::context-area gtk::info-bar-content-area (g-object gtk::widget)
+	 "gtk_info_bar_get_content_area" nil))))))
 
 (defun gtk-generate-child-properties (filename)
   (with-open-file (stream filename :direction :output :if-exists :supersede)

--- a/generating.lisp
+++ b/generating.lisp
@@ -373,7 +373,7 @@
        ("GtkInfoBar"
 	(:cffi gtk::action-area gtk::info-bar-action-area (g-object gtk::widget)
 	 "gtk_info_bar_get_action_area" nil)
-	(:cffi gtk::context-area gtk::info-bar-content-area (g-object gtk::widget)
+	(:cffi gtk::content-area gtk::info-bar-content-area (g-object gtk::widget)
 	 "gtk_info_bar_get_content_area" nil))))))
 
 (defun gtk-generate-child-properties (filename)

--- a/generating.lisp
+++ b/generating.lisp
@@ -70,7 +70,7 @@
                 "GtkTextTagTable" "GtkTreeModelFilter" "GtkTreeModelSort"
                 "GtkTreeSelection" "GtkTreeStore" "GtkUIManager" "GtkWindowGroup"
                 "GtkToggleAction" "GtkRecentAction" "GtkRadioAction" "GtkItemFactory"
-		"GtkPageSetupUnixDialog" "GtkPrintUnixDialog" "GtkInfoBar")
+		"GtkPageSetupUnixDialog" "GtkPrintUnixDialog" "GtkInfoBar" "GtkSpinner")
      :flags '("GtkTextSearchFlags" "GtkAccelFlags" "GtkArgFlags" "GtkAttachOptions"
               "GtkButtonAction" "GtkCalendarDisplayOptions" "GtkCellRendererState"
               "GtkDebugFlag" "GtkDestDefaults" "GtkDialogFlags" "GtkFileFilterFlags"

--- a/gtk/cl-gtk2-gtk.asd
+++ b/gtk/cl-gtk2-gtk.asd
@@ -68,6 +68,7 @@
                (:file "gtk.clipboard")
                (:file "gtk.info-bar")
 	       (:file "gtk.spinner")
+	       (:file "gtk.markup")
 
                (:file "gtk.main-loop-events")
 

--- a/gtk/cl-gtk2-gtk.asd
+++ b/gtk/cl-gtk2-gtk.asd
@@ -20,7 +20,7 @@
                (:file "gtk.main_loop_events")
                (:file "gtk.object")
                (:file "gtk.objects")
-               (:file "gtk.generated-classes")               
+               (:file "gtk.generated-classes")
                (:file "gtk.functions")
                (:file "gtk.base-classes")
                (:file "gtk.dialog")
@@ -66,18 +66,19 @@
                (:file "gtk.tree-store")
                (:file "gtk.tree-model-filter")
                (:file "gtk.clipboard")
-               
+               (:file "gtk.info-bar")
+
                (:file "gtk.main-loop-events")
-               
+
 
                (:file "gtk.generated-child-properties")
-               
+
                (:file "gtk.high-level")
 
                (:file "ui-markup")
 
                (:file "gtk.dialog.example")
-               
+
                (:file "gtk.demo")
                (:file "gtk.timer")
                (:file "gtk.finalize-classes")

--- a/gtk/cl-gtk2-gtk.asd
+++ b/gtk/cl-gtk2-gtk.asd
@@ -88,4 +88,4 @@
                         :pathname "demo/"
                         :components ((:plain-file "demo1" :type "ui")
                                      (:plain-file "text-editor" :type "ui"))))
-  :depends-on (:cl-gtk2-glib :cffi :cl-gtk2-gdk :bordeaux-threads :iterate :cl-gtk2-pango))
+  :depends-on (:cl-gtk2-glib :cffi :cl-gtk2-gdk :bordeaux-threads :iterate :metabang-bind :alexandria :cl-gtk2-pango))

--- a/gtk/cl-gtk2-gtk.asd
+++ b/gtk/cl-gtk2-gtk.asd
@@ -67,6 +67,7 @@
                (:file "gtk.tree-model-filter")
                (:file "gtk.clipboard")
                (:file "gtk.info-bar")
+	       (:file "gtk.spinner")
 
                (:file "gtk.main-loop-events")
 

--- a/gtk/gtk.info-bar.lisp
+++ b/gtk/gtk.info-bar.lisp
@@ -1,0 +1,15 @@
+(in-package :gtk)
+
+(defcfun (info-bar-add-button "gtk_info_bar_add_button") (g-object widget)
+  (info-bar    (g-object info-bar))
+  (button-text :string)
+  (response-id :int))
+
+(export 'info-bar-add-button)
+
+(defcfun (info-bar-add-action-widget "gtk_info_bar_add_action_widget") :void
+  (info-bar    (g-object info-bar))
+  (widget      (g-object widget))
+  (response-id :int))
+
+(export 'info-bar-add-action-widget)

--- a/gtk/gtk.markup.lisp
+++ b/gtk/gtk.markup.lisp
@@ -1,0 +1,11 @@
+(in-package :gtk)
+
+(defcfun |g_markup_escape_text| :string
+  (raw  :string)
+  (size :int))
+
+(defun markup-escape-text (raw)
+  (cffi:with-foreign-string (s raw)
+    (|g_markup_escape_text| s (length raw))))
+
+(export 'markup-escape-text)

--- a/gtk/gtk.package.lisp
+++ b/gtk/gtk.package.lisp
@@ -1,5 +1,5 @@
 (defpackage :gtk
-  (:use :cl :cffi :gobject :gdk :glib :iter :pango)
+  (:use :cl :alexandria :cffi :gobject :gdk :glib :iter :bind :pango)
   (:export #:gtk-main
            #:gtk-main-quit
            #:dialog-run

--- a/gtk/gtk.spinner.lisp
+++ b/gtk/gtk.spinner.lisp
@@ -1,0 +1,9 @@
+(in-package :gtk)
+
+(defcfun (spinner-start "gtk_spinner_start") :void
+  (spinner (g-object gtk:spinner)))
+
+(defcfun (spinner-stop "gtk_spinner_stop") :void
+  (spinner (g-object gtk:spinner)))
+
+(export '(spinner-start spinner-stop))


### PR DESCRIPTION
Hi,

I added the following things:
- Bindings for Widget GtkInfoBar
- Bindings for Widget GtkSpinner
- Bindings for g_markup_escape_text
- Graphical condition handling using the GtkInfoBar widget (I think this is the interesting one)
  See http://postimage.org/image/2gn4nvl0/

Additional Dependencies:
- Gtk 2.18 (InfoBar), 2.20 (Spinner)
- alexandria (for the condition handling code)
- metabang-bind (likewise)
