### PR TITLE
arguments to table-attach, left, right, top, bottom are required arg…

### DIFF
--- a/gtk/ui-markup.lisp
+++ b/gtk/ui-markup.lisp
@@ -82,11 +82,7 @@
   (unless bottom
     (error "bottom is a mandatory child property for table packing"))
 
-  (table-attach table child
-		:left left
-		:right right
-		:top top
-		:bottom bottom
+  (table-attach table child left right top bottom
 		:x-options x-options
 		:y-options y-options
 		:x-padding x-padding


### PR DESCRIPTION
It appears that someone tried to make these arguments into keyword arguments.
which is probably a good idea, but they updated the call-site without the function definition.
