### PR TITLE
Cffi compat

### DIFF
--- a/cairo/cairo.demo.lisp
+++ b/cairo/cairo.demo.lisp
@@ -128,7 +128,7 @@
   (declare (ignore w h))
   (move-to 0 100)
   (set-font-size 50)
-  (show-text "foo. Привет мир!"))
+  (show-text "hello world" )) ;; "foo. Привет мир!"))
 
 (defparameter *lis-a* 9)
 (defparameter *lis-b* 8)

--- a/cairo/cairo.demo.lisp
+++ b/cairo/cairo.demo.lisp
@@ -39,7 +39,9 @@
   (iter (for symbol in-package '#:cl-gtk2-cairo-demo)
         (when (and (fboundp symbol)
                    (starts-with (symbol-name symbol) "DRAW-"))
-          (for doc = (or (documentation (fdefinition symbol) t) (let ((*print-case* :downcase)) (format nil "~A" symbol))))
+          (for doc = (or (documentation (fdefinition symbol) t)
+			 (let ((*print-case* :downcase))
+			   (format nil "~A" symbol))))
           (collect (make-cairo-fn :name doc :fn symbol)))))
 
 (defun demo ()
@@ -69,6 +71,7 @@
                                             (cairo-fn-fn (tree-model-item cb-list iter)))))))
         (setf (combo-box-active-iter combo) (tree-model-iter-first cb-list))
         (widget-show w)))))
+
 
 (defun draw-clock-face (w h)
   "Draw a clock face"

--- a/glib/gobject.boxed.lisp
+++ b/glib/gobject.boxed.lisp
@@ -171,7 +171,7 @@
         (cond
           ((cstruct-slot-description-count slot)
            (setf (slot-value proxy slot-name) (make-array (list (cstruct-slot-description-count slot))))
-           (iter (with ptr = (foreign-slot-pointer native cstruct-type slot-name))
+           (iter (with ptr = (foreign-slot-pointer native (list :struct cstruct-type) slot-name))
                  (with array = (slot-value proxy slot-name))
                  (for i from 0 below (cstruct-slot-description-count slot))
                  (setf (aref array i)

--- a/glib/gobject.gvalue.lisp
+++ b/glib/gobject.gvalue.lisp
@@ -5,7 +5,7 @@
 
 @arg[g-value]{a C pointer to the GValue structure}"
   (loop
-     for i from 0 below (foreign-type-size 'g-value)
+     for i from 0 below (foreign-type-size '(:struct g-value))
      do (setf (mem-ref g-value :uchar i) 0)))
 
 (defun g-value-type (gvalue)

--- a/glib/gobject.object.low.lisp
+++ b/glib/gobject.object.low.lisp
@@ -83,7 +83,7 @@
                     (g-object-type-property-type object-type name))
                   args-names)))
   (let ((args-count (length args-names)))
-    (with-foreign-object (parameters 'g-parameter args-count)
+    (with-foreign-object (parameters '(:struct g-parameter) args-count)
       (loop
          for i from 0 below args-count
          for arg-name in args-names

--- a/gtk/gtk.generated-classes.lisp
+++ b/gtk/gtk.generated-classes.lisp
@@ -2063,7 +2063,11 @@
                         (:cffi keep-above gtk-window-keep-above :boolean nil
                          "gtk_window_set_keep_above")
                         (:cffi keep-below gtk-window-keep-below :boolean nil
-                         "gtk_window_set_keep_below")))
+			       "gtk_window_set_keep_below")))
+
+(defmethod print-object ((self gtk-window) stream)
+  (print-unreadable-object (self stream :type t :identity t)
+    nil))
 
 (define-g-object-class "GtkAssistant" assistant
                        (:superclass gtk-window :export t :interfaces
@@ -2288,6 +2292,13 @@
                         ("AtkImplementorIface" "GtkBuildable" "GtkOrientable")
                         :type-initializer "gtk_vbox_get_type")
                        nil)
+
+(defmethod print-object ((self v-box) stream)
+  (print-unreadable-object (self stream :type t :identity t)
+    nil))
+
+
+
 
 (define-g-object-class "GtkColorSelection" color-selection
                        (:superclass v-box :export t :interfaces

--- a/gtk/ui-markup.lisp
+++ b/gtk/ui-markup.lisp
@@ -82,11 +82,7 @@
   (unless bottom
     (error "bottom is a mandatory child property for table packing"))
 
-  (table-attach table child
-		:left left
-		:right right
-		:top top
-		:bottom bottom
+  (table-attach table child left right top bottom
 		:x-options x-options
 		:y-options y-options
 		:x-padding x-padding


### PR DESCRIPTION
CFFI is producing lots of compile time and runtime style warnings about use of bare struct and union names.
This PR tries to fix them.
